### PR TITLE
RA-1060: LOCAL_OWA_FOLDER is determined in config.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 node_modules
 bower_components
 dist
+config.json
 .idea
 
 *~

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -22,8 +22,6 @@ var livereload = require('gulp-livereload');
 
 var plugins = gulpLoadPlugins();
 
-var LOCAL_OWA_FOLDER = "C:\\Users\\user\\openmrs\\conceptdictionary\\owa";
-
 var THIS_APP_ID = 'conceptdictionary';
 
 var htmlGlob = ['app/**/*.html'];
@@ -74,9 +72,36 @@ gulp.task('watch', function() {
 	  gulp.watch('app/*', ['deploy-local']);
 });
 
-gulp.task('deploy-local', ['build'], function() {	
-  return gulp.src(['dist/**/*', '!*.zip'])
-    .pipe(gulp.dest(LOCAL_OWA_FOLDER + '\\' + THIS_APP_ID));
+gulp.task('deploy-local', ['build'], function() {
+    var config;
+    var localOwaFolder;
+
+	try {
+	  //Will throw exception when there is no config.json file
+  	  config = require('./config.json');
+      //Will throw exception when data in config.json is corrupted
+	  localOwaFolder = config.LOCAL_OWA_FOLDER;
+	} catch (err) {
+	  //Create or override config.json file
+	  var LOCAL_OWA_FOLDER_DEFAULT = "C:\\\\Users\\\\user\\\\openmrs\\\\conceptdictionary\\\\owa";
+	  var JSON_CONFIG_PATTERN_DEFAULT =
+	       "{\n" +
+	       "\"LOCAL_OWA_FOLDER\": " + "\"" + LOCAL_OWA_FOLDER_DEFAULT + "\"" +
+  	       "\n}";
+      var stream = fs.createWriteStream("config.json");
+      stream.once('open', function() {
+      stream.write(JSON_CONFIG_PATTERN_DEFAULT);
+      stream.end();
+
+      //Variables fixed
+      config = require('./config.json');
+      localOwaFolder = config.LOCAL_OWA_FOLDER;
+      })
+    } finally {
+      // Result
+      return gulp.src(['dist/**/*', '!*.zip'])
+            .pipe(gulp.dest(localOwaFolder + '/' + THIS_APP_ID));
+    }
 });
 
 gulp.task('build', ['resources', 'html'], function() {


### PR DESCRIPTION
https://issues.openmrs.org/browse/RA-1060

I realize that PawelGutkowski also tried to commit to this issue since I saw his pull request, but I didn't know about that when I were working on this issue (because we couldn't claim it on jira (issue is still in backlog))

The reason why I'm still doing pull request is better (IMHO) solution for this issue.
The difference is that in my solution config.json is created/overrided when gulp didn't find it or data inside is corrupted.
With this solution I've just added config.json to .gitignore file, so we don't have to bother about it when we add some files to git index (Which I think was our objective in this issue)

Cheers
Tomek
