### PR TITLE
RA-1054 Added concept search page

### DIFF
--- a/app/js/app.js
+++ b/app/js/app.js
@@ -4,6 +4,10 @@ var conceptDictionary = angular.module('conceptDictionary',
 conceptDictionary.config(['$routeProvider',
                     function($routeProvider) {
                       $routeProvider.
+                        when('/concept-search', {
+                            templateUrl: 'partials/concept-search.html',
+                            controller: 'ConceptSearchCtrl'
+                        }).
                         when('/class-list', {
                           templateUrl: 'partials/class-list.html',
                           controller: 'ClassesListCtrl',

--- a/app/js/controllers.js
+++ b/app/js/controllers.js
@@ -108,7 +108,7 @@ conceptDictControllers.controller('DataTypesDetailsCtrl', ['$scope', 'DataTypesS
 	
 	
 }]);
-conceptDictControllers.controller('ConceptViewCtrl', ['$scope', 'loadConcept', '$q', '$location', 'ConceptLocaleService', 
+conceptDictControllers.controller('ConceptViewCtrl', ['$scope', 'loadConcept', '$q', '$location', 'ConceptLocaleService',
                                                function($scope, loadConcept, $q, $location, ConceptLocaleService){ 
 	//resolves promise of fetching concept from server
 	$q.all(loadConcept).then(function(response){
@@ -134,4 +134,77 @@ conceptDictControllers.controller('ConceptViewCtrl', ['$scope', 'loadConcept', '
 	$scope.goToConcept = function(hash){
 		$location.path("/concept/"+hash);
 	}
+}]);
+conceptDictControllers.controller('ConceptSearchCtrl', ['$scope', 'ConceptsService', function($scope, ConceptsService) {
+	$scope.query='';
+	$scope.enableDescription = false;
+	$scope.concepts='';
+	$scope.isUserTyping = false;
+	$scope.searchNotification = 'Searching...';
+	$scope.noSearchInputNotification = 'Type query to search panel to find concepts';
+
+	//Default values
+	$scope.entriesPerPage = 5;
+	$scope.pageNumber = 1;
+	$scope.resultNotification = '';
+
+	$scope.loadingMorePages = false;
+
+	//Page changing
+	$scope.nextPage = function () {
+		$scope.pageNumber++;
+	};
+	$scope.prevPage = function () {
+		$scope.pageNumber--;
+	};
+	$scope.firstPage = function () {
+		$scope.pageNumber = 1;
+	};
+	$scope.lastPage = function () {
+		$scope.pageNumber = Math.floor($scope.concepts.length/$scope.entriesPerPage)+1;
+	};
+
+
+	$scope.updateResultNotification = function () {
+		if ($scope.isUserTyping) {
+			$scope.resultNotification = '';
+		}
+		else {
+			$scope.resultNotification = 'There is no concept named ' + $scope.query;
+		}
+	};
+
+	// Method used to prevent app from querying server with every letter input into search query panel
+	var timeout = null;
+	$scope.timeoutRefresh = function() {
+		clearTimeout(timeout);
+		$scope.isUserTyping = true;
+		timeout = setTimeout(function () {
+			$scope.refreshResponse();
+		}, 250);
+	};
+
+	$scope.refreshResponse = function() {
+		$scope.firstPage();
+		$scope.isUserTyping = false;
+
+		if ($scope.query.length>0) {
+			ConceptsService.getFirstPageQueryConcepts($scope.query, $scope.entriesPerPage).then(function (firstResponse) {
+				$scope.loadingMorePages = true;
+				$scope.concepts = firstResponse.results;
+				$scope.updateResultNotification();
+
+				ConceptsService.getQueryConcepts($scope.query).then(function (response) {
+					$scope.concepts = response.results;
+					$scope.updateResultNotification();
+					$scope.loadingMorePages = false;
+				});
+			});
+		}
+		else {
+			$scope.$apply(function () {
+				$scope.concepts='';
+			});
+		}
+	};
 }]);

--- a/app/js/services.js
+++ b/app/js/services.js
@@ -172,4 +172,34 @@ conceptDictServices
 			}
 		}
 	}
+}])
+.factory('Concepts',['$resource', 'Util', function($resource, Util){
+	return $resource(
+		Util.getOpenmrsContextPath()+'/ws/rest/v1/concept/:uuid?:mode:showRetired:query:limit', {},
+		//Returns single concept
+		{getConcept: {method: 'GET', isArray:false },
+		//Returns concepts filtered by query
+		getQueryConcepts: {method: 'GET', params:{mode : 'v=full', showRetired : '&includeAll=true'}, isArray:false},
+		//Returns first page concepts filtered by query
+		getFirstPageQueryConcepts: {method: 'GET', params:{mode : 'v=full', showRetired : '&includeAll=true'}, isArray:false},
+		});
+
+}])
+.factory('ConceptsService',['Concepts', function(Concepts){
+	return{
+		//Returns single concept
+		getConcept: function(uuid){
+			return Concepts.getConcept(uuid);
+		},
+		//Returns concepts filtered by query
+		getQueryConcepts: function(searchTerm){
+			searchTerm = '&q=' + searchTerm;
+			return Concepts.getQueryConcepts({query: searchTerm}).$promise;
+		},
+		getFirstPageQueryConcepts: function(searchTerm, entitiesPerPage) {
+			searchTerm = '&q=' + searchTerm;
+			entitiesPerPage = '&limit=' + entitiesPerPage;
+			return Concepts.getFirstPageQueryConcepts({query: searchTerm, limit : entitiesPerPage}).$promise;
+		}
+	}
 }]);

--- a/app/partials/concept-search.html
+++ b/app/partials/concept-search.html
@@ -1,0 +1,80 @@
+<div>
+    <h2>Concept Dictionary Maintenance</h2>
+    <b>Find Concept(s)</b>
+    <div>
+        <div>
+            <span>
+                <span>Find a concept by typing in its name:</span>
+                            <input id="inputNode" type="text" ng-model="query" ng-change="timeoutRefresh()">
+                            <input id="searchButton" name="searchButton" value="Search" type="button" ng-click="refreshResponse()">
+                            <br>
+                            <input id="includeVerbose" type="checkbox" ng-model="enableDescription">
+                            <label for="includeVerbose">Show Details</label>
+                            <br>
+                            <br>
+
+                <span style="display: inline;">
+                    <div align="center">
+
+                        <span ng-show="isUserTyping && query.length > 0"> <b>{{searchNotification}}</b> </span>
+                        <br>
+                        <img ng-show="isUserTyping && query.length > 0" src="../../moduleResources/webservices/rest/js/swagger-ui/dist/images/inprogress.gif" width="64" height="64">
+                        <span ng-show="query.length == 0 && !isUserTyping"><b>{{noSearchInputNotification}}</b></span>
+                        <span ng-show="query.length > 0 && concepts.length == 0 && !isUserTyping"><b>{{resultNotification}}</b></span>
+
+                        <table ng-show="concepts.length > 0 && query.length > 0 && !isUserTyping" border="solid" style="width: 100%">
+                            <thead>
+                            <tr>
+                                <td valign="top">Name</td>
+                                <td ng-show="enableDescription">Description</td>
+                            </tr>
+                            </thead>
+                            <tbody>
+                            <tr ng-repeat="concept in concepts.slice(entriesPerPage*pageNumber-entriesPerPage,entriesPerPage*pageNumber)">
+                                <td valign="top">
+                                    <a href="#/concept/{{concept.uuid}}">
+                                        <span ng-show="concept.retired"><del>{{concept.display}}</del></span>
+                                        <span ng-show="!concept.retired">{{concept.display}}</span>
+                                    </a>
+                                </td>
+                                <td ng-show="enableDescription">
+                                    {{concept.descriptions[0].description}}
+                                </td>
+                            </tr>
+                            </tbody>
+                        </table>
+
+                        <span ng-show="!isUserTyping && concepts.length && !loadingMorePages> 0">
+                            Found <b>{{concepts.length}}</b> entries
+                        </span>
+                        <br>
+                        <span ng-show="!isUserTyping && concepts.length > 0">
+                            View range: {{entriesPerPage*pageNumber+1-entriesPerPage}} to {{entriesPerPage*pageNumber}}
+                        </span>
+                        <br>
+                        <span ng-show="!isUserTyping && concepts.length > 0">
+                            Page: {{pageNumber}}
+                        </span>
+                        <br>
+                        <br>
+                        <input type="button" ng-show="!isUserTyping && concepts.length > 0" ng-disabled="pageNumber == 1" ng-click="firstPage()" value="First Page">
+                        <input type="button" ng-show="!isUserTyping && concepts.length > 0" ng-disabled="pageNumber == 1" ng-click="prevPage()" value="Previous Page">
+                        <input type="button" ng-show="!isUserTyping && concepts.length > 0" ng-disabled="entriesPerPage*pageNumber >= concepts.length" ng-click="nextPage()" value="Next Page">
+                        <input type="button" ng-show="!isUserTyping && concepts.length > 0" ng-disabled="entriesPerPage*pageNumber >= concepts.length" ng-click="lastPage()" value="Last Page">
+
+                        <div ng-show="!isUserTyping && concepts.length > 0" align="left">
+                            Show
+                            <select size="1" ng-model="entriesPerPage" ng-click="firstPage()">
+                                <option selected="selected" value="5">5</option>
+                                <option value="10">10</option>
+                                <option value="25">25</option>
+                                <option value="50">50</option>
+                            </select>
+                            entries
+                        </div>
+                    </div>
+                </span>
+            </span>
+        </div>
+    </div>
+</div>

--- a/test/unit/controllerSpec.js
+++ b/test/unit/controllerSpec.js
@@ -149,7 +149,7 @@ describe('Concept dictionary controllers', function() {
         });
 
     });
-    
+
     describe('DataTypesListCtrl', function(){
    	 var scope, ctrl, $httpBackend;
    	 
@@ -205,4 +205,66 @@ describe('Concept dictionary controllers', function() {
 	   		 
 	   	 });
    });
+
+    describe('ConceptSearchCtrl', function() {
+        var scope, ctrl, $httpBackend;
+
+        beforeEach(inject(function(_$httpBackend_, $rootScope, $controller, Util, ConceptsService) {
+            var testQuery = 'Ana';
+            $httpBackend = _$httpBackend_;
+            $httpBackend.expectGET(Util.getOpenmrsContextPath()+'/ws/rest/v1/concept/?v=full&includeAll=true&q=' + testQuery).
+            respond(
+                {results: [
+                    {
+                        uuid: '80bd49d3-4a3b-4566-95be-8a4cf4b411f4',
+                        display: 'Anaphylaxis',
+                        datatype: {description: 'An acute hypersensitivity reaction due to exposure to a previously encountered antigen.' +
+                        ' The reaction may include rapidly progressing urticaria, respiratory distress, vascular collapse, systemic shock, and death.'}
+                    },
+                    {
+                        uuid: '3fc4d6bd-7206-4d7d-9ec3-b5fa7822e3df',
+                        display: 'Anaemia',
+                        datatype: {description: 'A reduction in the number of circulating erythrocytes or in the quantity of hemoglobin.'}
+                    },
+                    {
+                        uuid: 'd0a052f7-b6fd-4f3e-8385-7dc06d6f3806',
+                        display: 'Anacin Aspirin Regimen',
+                        datatype: {description: 'Name of a drug which is used as anti inflammatory and analgesic.'}
+                    }
+                ]});
+
+            scope = $rootScope.$new();
+
+            scope.concepts = '';
+
+            ConceptsService.getQueryConcepts(testQuery).then(function (response) {
+                scope.concepts = response;
+            });
+
+            ctrl = $controller('ConceptSearchCtrl', {$scope: scope, $location: location});
+        }));
+
+        it('should get data with specified query', function() {
+            $httpBackend.flush();
+            expect(scope.concepts).toEqualData(
+                {results: [
+                    {
+                        uuid: '80bd49d3-4a3b-4566-95be-8a4cf4b411f4',
+                        display: 'Anaphylaxis',
+                        datatype: {description: 'An acute hypersensitivity reaction due to exposure to a previously encountered antigen.' +
+                        ' The reaction may include rapidly progressing urticaria, respiratory distress, vascular collapse, systemic shock, and death.'}
+                    },
+                    {
+                        uuid: '3fc4d6bd-7206-4d7d-9ec3-b5fa7822e3df',
+                        display: 'Anaemia',
+                        datatype: {description: 'A reduction in the number of circulating erythrocytes or in the quantity of hemoglobin.'}
+                    },
+                    {
+                        uuid: 'd0a052f7-b6fd-4f3e-8385-7dc06d6f3806',
+                        display: 'Anacin Aspirin Regimen',
+                        datatype: {description: 'Name of a drug which is used as anti inflammatory and analgesic.'}
+                    }
+                ]});
+        });
+    });
 });


### PR DESCRIPTION
I've added concept search page, which needs upgrades:
- I'm downloading whole concept dictionary at beginning (REST methods can return only single object or whole dictionary), that may cause user to download lots of data he won't use, but makes searching very dynamic (refresh rate when changing query is client-sided, so its very fast)
- I couldn't get retired concepts (REST returns whole dictionary without retired ones), so I didn't implement "Show retired" checkbox

//edit
- Didn't implement searching by ID -> There is no "id" field in REST json response object
