### PR TITLE
🔃Add Browsersync

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -18,7 +18,7 @@ var gulpLoadPlugins = require('gulp-load-plugins');
 var del = require('del');
 var mainBowerFiles = require('main-bower-files');
 var wiredep = require('wiredep').stream;
-var livereload = require('gulp-livereload');
+var browserSync = require('browser-sync').create();
 
 var plugins = gulpLoadPlugins();
 
@@ -85,12 +85,22 @@ gulp.task('resources', function() {
     .pipe(gulp.dest('dist'));
 });
 
-gulp.task('watch', function() {
-	  livereload.listen();
-	  gulp.watch('app/*', ['deploy-local']);
-	  gulp.watch('app/**/*.*', ['deploy-local']);
+gulp.task('browser-sync-reload', ['deploy-local'], function() {
+  browserSync.reload();
 });
 
+gulp.task('watch', function() {
+  // forget about all the error checking for now
+  var config = require('./config.json');
+
+  browserSync.init({
+    proxy: {
+      target: config.APP_ENTRY_POINT
+    }
+  });
+
+  gulp.watch('app/**/*.*', ['browser-sync-reload']);
+});
 
 gulp.task('deploy-local', ['build'], function() {
     var config;

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "wiredep": "^3.0.0"
   },
   "devDependencies": {
-    "gulp-livereload": "^3.8.1",
+    "browser-sync": "^2.11.1",
     "gulp-watch": "^4.3.5",
     "jasmine-core": "^2.4.1",
     "karma": "^0.13.21",


### PR DESCRIPTION
I'm thinking about using this setup with Browsersync for the generator. Basically, it runs as a proxy and injects a script into the page to do things like automatically deploy _and_ reload the page on file change, as well as sync actions (like scroll & keyboard events) across browser instances.

To test, you'll need to run `npm install` again and add the `APP_ENTRY_POINT` property into your `config.json` file. It should end up looking something like this:

``` js
{
  "LOCAL_OWA_FOLDER": "/Users/pascal/Downloads/openmrs-standalone-2.3.1/appdata/owa/",
  "APP_ENTRY_POINT": "http://localhost:8082/openmrs-standalone/owa/conceptdictionary/index.html"
}
```

Let me know what you think.
