### PR TITLE
fix disable retire button bug in concept source edit page

### DIFF
--- a/app/components/drugList/drugList.html
+++ b/app/components/drugList/drugList.html
@@ -14,8 +14,8 @@
 			</tr>
 			</thead>
 			<tbody>
-			<tr ng-repeat="drug in vm.drugsList" ng-class="{retired: drug.retired}">
-				<td>{{drug.name}}</td>
+			<tr ng-repeat="drug in vm.drugsList" >
+				<td ng-class="{retired: drug.retired}">{{drug.name}}</td>
 				<td>
 					<a href="#/drug/{{drug.uuid}}"><i class="icon-pencil edit-action" title="Edit"></i></a>
 					<a ng-show="!drug.retired" ng-click="vm.retire(drug)">

--- a/app/components/sourceEdit/sourceEdit.controller.js
+++ b/app/components/sourceEdit/sourceEdit.controller.js
@@ -23,7 +23,6 @@ function SourceEditController (sources ,openmrsRest, $location){
 
     vm.source = sources;
 
-
     vm.responseMessage = '';
 
     vm.cancel = cancel;
@@ -31,6 +30,17 @@ function SourceEditController (sources ,openmrsRest, $location){
     vm.isSavePossible = isSavePossible;
     vm.retire = retire;
     vm.deleteForever = deleteForever;
+    
+    activate();
+    
+    
+    
+    function activate(){
+    	if(angular.isDefined(vm.source.auditInfo)&&
+    	   angular.isUndefined(vm.source.auditInfo.retireReason)){
+    			vm.source.auditInfo.retireReason = ""; 
+    	}
+    }
 
     function cancel () {
         $location.path('/source');

--- a/app/components/sourceEdit/sourceEdit.html
+++ b/app/components/sourceEdit/sourceEdit.html
@@ -55,7 +55,7 @@
 				<h2><i class="icon-lock"></i>{{"Retire" | translate}}</h2>
 				<label>{{"RetireReason" | translate}}<span class="required">*</span></label>
 				<textarea ng-model="vm.source.auditInfo.retireReason" rows="3" cols="50"></textarea>
-				<button ng-disabled="vm.source.auditInfo.retireReason.length() == 0" ng-click="vm.retire()">
+				<button ng-disabled="vm.source.auditInfo.retireReason.length < 1" ng-click="vm.retire()">
 					<i class="icon-lock"></i>&#160;Retire
 				</button>
 			</div>


### PR DESCRIPTION
Condition in ng-disable doesn't handle situation when retireReason is undefined, so until user write anything into textbox, button is always enabled. I fixed it by initializing retireReason to empty string, if it is undefined. Second bug is that ng-class i on whole row, so when drug is retired, there are dashes between icons of actions: ![pic related](https://cloud.githubusercontent.com/assets/17570261/14387279/fc699846-fda8-11e5-900a-1b7489135d83.png). Fixed it with moving ng-class to table cell. I will keep looking for more.
