### PR TITLE
Unmangle

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -156,11 +156,11 @@ gulp.task('lint', function() {
     .pipe(eslint())
     .pipe(eslint.format())
     .pipe(eslint.failAfterError());
-}); 
+});
 
 gulp.task('compress', ['resources', 'html'], function() {
 	  return gulp.src('dist/**/*.js')
-	    .pipe(uglify())
+	    .pipe(uglify({ mangle: false }))
 	    .pipe(gulp.dest('dist'))
 });
 


### PR DESCRIPTION
Uglify was mangling some of the Angular stuff.

The official release is not currently working and we should publish a new build using this fix.

cc @rkorytkowski @PawelGutkowski 
