### PR TITLE
Fixed Reference Term adding

### DIFF
--- a/app/components/referenceEdit/referenceEdit.controller.js
+++ b/app/components/referenceEdit/referenceEdit.controller.js
@@ -40,12 +40,15 @@ export default function ReferenceEditController (reference, sources, openmrsRest
     }
 
     function updateConceptSource() {
-        for (i = 0; i < vm.sources.length; i++) {
+        var i = 0;
+        do {
             if (vm.sources[i].name === vm.selectedConceptSource) {
                 vm.reference.conceptSource = vm.sources[i];
                 break;
             }
+            i++;
         }
+        while(i < vm.sources.length);
     }
 
     function isSavePossible () {


### PR DESCRIPTION
updateConceptSource() didn't work when adding new Reference term, which allowed user to edit existing references, but didn't allow user to add new ones.
