### PR TITLE
RA-1103 fix undefined combination error, when adding new drug

### DIFF
--- a/app/components/drugEdit/drugEdit.controller.js
+++ b/app/components/drugEdit/drugEdit.controller.js
@@ -65,6 +65,7 @@ export default function DrugEditController($location, openmrsRest, loadDrug){
 				vm.drug.auditInfo.retireReason = "";
 			}
         } else {
+        	vm.drug.combination = false;
 			vm.drug.concept = {
 				display: ''
 			};


### PR DESCRIPTION
Adding new Drug fails if user didn't check 'combination' checkbox, because vm.drug.combination variable is uninitialized and method toString below fails. This commit fixes it.
