### PR TITLE
Copy webapp icon to build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -104,6 +104,11 @@ plugins.push(new CopyWebpackPlugin([{
     from: './app/manifest.webapp'
 }]));
 
+plugins.push(new CopyWebpackPlugin([{
+    from: './app/img/omrs-button.png',
+    to: 'img/omrs-button.png'
+}]));
+
 plugins.push(new OccurenceOrderPlugin());
 
 plugins.push(new WebpackMd5Hash());


### PR DESCRIPTION
Pascal pointed out, that icon declared in webpack.manifest should be copied to build, because it is not showed on 'Manage Apps' page. Now it should work.
