### PR TITLE
Cut the production build time

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -69,9 +69,7 @@ if (env === 'production') {
     },
     minimize: true,
     sourceMap: false,
-    compress: {
-        warnings: false
-    }
+    compress: false
   }));
   plugins.push(new DedupePlugin());
   outputFile = `${outputFile}.min.[chunkhash].js`;
@@ -156,16 +154,7 @@ var config = {
 	},{
 	    test: /\.html$/,
 	    loader: 'raw'
-	}, {
-        test: /\.scss$/,
-        loader: "style!css!sass?outputStyle=expanded&includePaths[]=" 
-        		+ path.resolve(__dirname, "./node_modules/compass-mixins/lib")
-      },
-        {test: /\.woff(\?v=\d+\.\d+\.\d+)?$/, loader: 'url'},
-        {test: /\.woff2(\?v=\d+\.\d+\.\d+)?$/, loader: 'url'},
-        {test: /\.ttf(\?v=\d+\.\d+\.\d+)?$/, loader: 'url'},
-        {test: /\.svg(\?v=\d+\.\d+\.\d+)?$/, loader: 'url'},
-        {test: /\.eot(\?v=\d+\.\d+\.\d+)?$/, loader: 'url'},],
+	}],
   },
   resolve: {
     root: path.resolve('./src'),


### PR DESCRIPTION
Lately our production build times got up to 200s [link](https://travis-ci.org/rkorytkowski/openmrs-owa-conceptdictionary/builds/130767386). It seems that compressing is taking so long, as we are using already compressed and minified openmrs-contrib-uicommons library. Compression doesn't reduce our app size, so I should we think disable it. Build time is reduced to 7-8 seconds max.

Besides, loaders for scss are redundant, as we don't have any.
