### PR TITLE
RA-1146 - Indicate class and concept_id when searching concepts

### DIFF
--- a/app/components/conceptSearch/conceptSearch.controller.js
+++ b/app/components/conceptSearch/conceptSearch.controller.js
@@ -27,6 +27,14 @@ export default function ConceptSearchController($scope, $routeParams, openmrsRes
         {
             "property": "name.name",
             "label": "Concept.name"
+        },
+        {
+            "property": "conceptClass.name",
+            "label":"class"
+        },
+        {
+            "property": "uuid",
+            "label":"uuid"
         }];
     vm.actions = [
         {


### PR DESCRIPTION
This PR refers to https://github.com/PawelGutkowski/openmrs-contrib-uicommons/pull/32 and should be merged after it
@rkorytkowski What did You mean by "shortened UUIDs"?
Now it looks like that: [>CLICK<](http://i.imgur.com/wS7WJ77.png)
